### PR TITLE
Fix Image Bug Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY target/*.jar app.jar
 
 # Slimmer runtime environment
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre-alpine-3.21
 WORKDIR /app
 COPY --from=jar-copier /app/app.jar .
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY target/*.jar app.jar
 
 # Slimmer runtime environment
-FROM eclipse-temurin:17-jre-alpine-3.21
+FROM eclipse-temurin:17-jre-jammy
 WORKDIR /app
 COPY --from=jar-copier /app/app.jar .
 EXPOSE 8080


### PR DESCRIPTION
So apparently the Temurin project discontinued Alpine based JRE builds (due to musl-libc compatibility issues), so Docker Hub has no such tag.

Changed from Alpine to jre-jammy (Debian ubuntu based)