### PR TITLE
Fix pre-release tag having multiple "pre" prefixes

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -3,7 +3,7 @@ name: Prerelease
 on:
   push:
       branches:
-        - main
+        - bug/versioning
       tags: ["v[0-9]+.[0-9]+.[0-9]+"]
 
 jobs:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Calculate pre-release version
         run: |
           VERSION=${latest_tag#v}
+          VERSION=${VERSION%%-pre*}
           MAJOR=$(echo "$VERSION" | cut -d . -f 1)
           MINOR=$(echo "$VERSION" | cut -d . -f 2)
           PATCH=$(echo "$VERSION" | cut -d . -f 3)

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -3,7 +3,7 @@ name: Prerelease
 on:
   push:
       branches:
-        - bug/versioning
+        - main
       tags: ["v[0-9]+.[0-9]+.[0-9]+"]
 
 jobs:


### PR DESCRIPTION
I tested it here on this branch. The new tag appeared on the main branch and you can see it correctly removed the "-pre-pre-pre". It didnt increment as the prerelease workflow was caused by a push to main.