### PR TITLE
Added user feedback processing

### DIFF
--- a/src/main/java/com/remla6/app/controller/ModelController.java
+++ b/src/main/java/com/remla6/app/controller/ModelController.java
@@ -2,7 +2,9 @@ package com.remla6.app.controller;
 
 import com.remla6.app.exception.InferenceFailedException;
 import com.remla6.app.metric.WebMetrics;
+import com.remla6.app.model.FeedbackModel;
 import com.remla6.app.model.SentimentModel;
+import com.remla6.app.service.FeedbackService;
 import com.remla6.app.service.ModelService;
 import io.micrometer.core.instrument.Timer;
 import lombok.AllArgsConstructor;
@@ -13,7 +15,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.remla25team6.libversion.VersionUtil;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @AllArgsConstructor
@@ -21,6 +26,7 @@ import java.util.List;
 @RequestMapping("/")
 public class ModelController {
     private final ModelService modelService;
+    private final FeedbackService feedbackService;
     private final WebMetrics metrics;
 
     /**
@@ -33,6 +39,71 @@ public class ModelController {
     public String index(Model model) {
         model.addAttribute("version", VersionUtil.getVersion());
         return "index";
+    }
+
+    /**
+     * Receive and persist user inference disagreements.
+     * @param disagreeIds The respective id's
+     * @param model The MVC Model
+     * @param redirectAttributes MVC parameter
+     * @return A redirect to the homepage, accompanied by succes or error message
+     */
+    @PostMapping("/train")
+    public String handleDisagreements(@RequestParam(value = "disagreeIds", required = false) List<Long> disagreeIds,
+                                      Model model,
+                                      RedirectAttributes redirectAttributes) {
+        try {
+            if (disagreeIds == null || disagreeIds.isEmpty()) {
+                redirectAttributes.addFlashAttribute("errorMessage", "No disagreements selected");
+                return "redirect:/";
+            }
+
+            // Collect the disagreed predictions for feedback
+            List<FeedbackModel> feedbackEntries = new ArrayList<>();
+
+            for (Long id : disagreeIds) {
+                // Retrieve the response from your storage (e.g., in-memory cache, database)
+                SentimentModel response = modelService.findById(id);
+
+                if (response != null) {
+                    // Create feedback entry with flipped sentiment
+                    String correctedSentiment = response.getSentiment().equals("pos") ? "neg" : "pos";
+
+                    FeedbackModel feedback = new FeedbackModel(
+                            id,
+                            response.getInputString(),
+                            correctedSentiment
+                    );
+
+                    feedbackEntries.add(feedback);
+                }
+            }
+
+            // Send feedback to model-service
+            if (!feedbackEntries.isEmpty()) {
+                feedbackService.storeFeedback(feedbackEntries);
+
+                redirectAttributes.addFlashAttribute("successMessage",
+                        String.format("Successfully submitted %d corrections for training", feedbackEntries.size()));
+            }
+
+            return "redirect:/";
+
+        } catch (Exception e) {
+            redirectAttributes.addFlashAttribute("errorMessage",
+                    "Failed to submit feedback. Please try again later.");
+            return "redirect:/";
+        }
+    }
+
+    /**
+     * Rest endpoint serving as an API for broadcasting user corrected sentiment
+     * @return List of all FeedbackModel objects in database
+     */
+    @GetMapping("/train")
+    @ResponseBody // Without this it needs HTML templating. Now it serves similarly to an api.
+    public List<FeedbackModel> getUserFeedback() {
+        return feedbackService.fetchFeedback();
     }
 
     /**

--- a/src/main/java/com/remla6/app/model/FeedbackModel.java
+++ b/src/main/java/com/remla6/app/model/FeedbackModel.java
@@ -1,0 +1,48 @@
+package com.remla6.app.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
+import org.hibernate.annotations.SQLInsert;
+
+@Entity
+public class FeedbackModel {
+    @Id
+    private long id;
+
+    private String review;
+    private String correctSentiment;
+
+    public FeedbackModel() {}
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getReview() {
+        return review;
+    }
+
+    public void setReview(String review) {
+        this.review = review;
+    }
+
+    public String getCorrectSentiment() {
+        return correctSentiment;
+    }
+
+    public void setCorrectSentiment(String correctSentiment) {
+        this.correctSentiment = correctSentiment;
+    }
+
+    public FeedbackModel(Long id, String review, String correctSentiment) {
+        this.review = review;
+        this.correctSentiment = correctSentiment;
+        this.id = id;
+    }
+}

--- a/src/main/java/com/remla6/app/repository/FeedbackRepository.java
+++ b/src/main/java/com/remla6/app/repository/FeedbackRepository.java
@@ -1,0 +1,9 @@
+package com.remla6.app.repository;
+
+import com.remla6.app.model.FeedbackModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FeedbackRepository extends JpaRepository<FeedbackModel, Long> {
+}

--- a/src/main/java/com/remla6/app/service/FeedbackService.java
+++ b/src/main/java/com/remla6/app/service/FeedbackService.java
@@ -1,0 +1,25 @@
+package com.remla6.app.service;
+
+import com.remla6.app.model.FeedbackModel;
+import com.remla6.app.repository.FeedbackRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class FeedbackService {
+    private FeedbackRepository feedbackRepository;
+
+    public FeedbackService(FeedbackRepository feedbackRepository) {
+        this.feedbackRepository = feedbackRepository;
+    }
+
+    public void storeFeedback(List<FeedbackModel> feedback) {
+        feedbackRepository.saveAll(feedback);
+    }
+
+    public List<FeedbackModel> fetchFeedback() {
+        return feedbackRepository.findAll();
+    }
+
+}

--- a/src/main/java/com/remla6/app/service/ModelService.java
+++ b/src/main/java/com/remla6/app/service/ModelService.java
@@ -5,9 +5,11 @@ import com.remla6.app.dto.PredictResponse;
 import com.remla6.app.exception.InferenceFailedException;
 import com.remla6.app.model.SentimentModel;
 import com.remla6.app.repository.SentimentRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 import org.springframework.beans.factory.annotation.Value;
 
@@ -47,7 +49,7 @@ public class ModelService {
                 .toEntity(PredictResponse.class);
 
         // Check if response = 200
-        if (response.getBody() == null) {
+        if (response.getStatusCode() != HttpStatus.OK) {
             throw new InferenceFailedException("Model currently unavailable, try again later.");
         }
 
@@ -59,6 +61,9 @@ public class ModelService {
         return sentimentRepository.save(model);
     }
 
+    public SentimentModel findById(Long id){
+        return sentimentRepository.findById(id).orElse(null);
+    }
     /**
      * Method to retrieve all inference results from the persistence repository.
      * @return List of SentinentModel

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -35,8 +35,14 @@
             margin-top: 20px;
             text-align: center;
         }
-        /* Spacer to ensure space for error message at bottom */
-        .error-spacer {
+        /* Success text styling */
+        .success-text {
+            color: green;
+            margin-top: 20px;
+            text-align: center;
+        }
+        /* Spacer to ensure space for messages at bottom */
+        .message-spacer {
             height: 3em;
         }
     </style>
@@ -81,10 +87,13 @@
 <!-- 3) Version display -->
 <div class="version" th:text="'Version: ' + ${version}">Version: 1.0.0</div>
 
-<!-- Spacer for error message -->
-<div class="error-spacer"></div>
+<!-- Spacer for messages -->
+<div class="message-spacer"></div>
 
-<!-- Optional error message -->
+<!-- Success message -->
+<div th:if="${successMessage}" class="success-text" th:text="${successMessage}">Success message here</div>
+
+<!-- Error message -->
 <div th:if="${errorMessage}" class="error-text" th:text="${errorMessage}">Error message here</div>
 
 </body>


### PR DESCRIPTION
### Changes made
* Added /train GET and POST endpoint
    * ```GET /train``` serves to retrieve all user-corrected inferences that are persisted by the APP
    * ```POST /train``` serves to persist all user-corrected inferences, uses the main-page button
### Is this what the assignment wants?
The assignment specifies _"For example, an operator can flag/change
incorrect predictions or (implicit) user input is leveraged for validation or growing the dataset."_.

Currently this approach stores user-corrected inferences on the _App_ side. Additionally the App then exposes an API-endpoint ```GET /train```, where currently any interested party can retrieve a full list of corrected inferences, tied to a unique id. 

A possible different approach is the model-service doing exactly this, and the app providing the corrections. One thing against this approach is that the app already has persistence configured and the model-training is not part of the kubernetes cluster anyway. If it was one could argue that having the model-service expose this API is preferable, since then it is not public-facing.

### How-to-test
To test the app in isolation you will need a mock-model-service. You can use the following python Flask app:
```python
from flask import Flask
import random

app = Flask(__name__)

@app.post("/predict")
def spoof():
    if random.randint(0, 1) > 0.5:
        res = "pos"
    else:
        res = "neg"
    return {
        "sentiment": res
    }
```
Then make sure to export ```MODEL_URL=http://127.0.0.1:5000``` (or a different value if your flask does not use this endpoint).

Then you can test the following:
- One or more inference results can be marked as wrong and the button submits these for persistence.
- The persisted inferences can be retrieved with ```GET /train``` and coincide with the submitted inferences.
- If a duplicated inference is selected by the user it does not get stored twice.