### PR TITLE
Feature/add gauge metric

### DIFF
--- a/src/main/java/com/remla6/app/controller/ModelController.java
+++ b/src/main/java/com/remla6/app/controller/ModelController.java
@@ -53,6 +53,9 @@ public class ModelController {
         Timer.Sample sample = metrics.startInferenceTimer();
         SentimentModel sentiment;
 
+        // Update text length metrics
+        metrics.updateTextLengthMetrics(review);
+
         // Process and persist inference
         try {
             sentiment = modelService.processSentiment(review);

--- a/src/main/java/com/remla6/app/metric/WebMetrics.java
+++ b/src/main/java/com/remla6/app/metric/WebMetrics.java
@@ -73,7 +73,7 @@ public class WebMetrics {
         // Average text length gauge
         averageTextLengthGauge = Gauge.builder("app_average_text_length", 
                 this,
-                this::calculateAverageTextLength)
+                ignored -> this.calculateAverageTextLength())
                 .description("Average length of processed text inputs")
                 .tags("application", "app")
                 .register(registry);


### PR DESCRIPTION
Added gauge metric to measure the average length of the requests. 

example of how it is displayed in grafana:

![image](https://github.com/user-attachments/assets/fafb595f-0c72-4491-81ec-90f5874902fe)

(Separate PR will be made in operation for updated grafana view)